### PR TITLE
For loop optimization

### DIFF
--- a/SteamDatabase.user.js
+++ b/SteamDatabase.user.js
@@ -71,7 +71,7 @@ SteamDB =
 		
 		var i = 0, appid = 0;
 		
-		for( i = 0; i < container.length; i++ )
+		for( i = 0, l = container.length; i < l; i++ )
 		{
 			element = container[ i ];
 			


### PR DESCRIPTION
you want to cache `length`s because otherwise the second portion of the `for` loop will have to call the variable every time, even though the value doesn't change
