### PR TITLE
Fixed for_item param always giving error 26

### DIFF
--- a/BrowserExtension/scripts/community/tradeoffer_new.js
+++ b/BrowserExtension/scripts/community/tradeoffer_new.js
@@ -19,8 +19,8 @@ if( item !== null )
 			    "assets": [
 			        {
 			            "appid": appid,
-			            "contextid": contextid,
-			            "assetid": assetid,
+			            "contextid": contextid.toString(),
+			            "assetid": assetid.toString(),
 			            "amount": 1
 			        }
 			    ],


### PR DESCRIPTION
contextid and assetid MUST be strings apparently