### PR TITLE
Fix icon not showing up on browser add-ons page

### DIFF
--- a/BrowserExtension/package.json
+++ b/BrowserExtension/package.json
@@ -6,7 +6,7 @@
 	"id": "firefox-extension@steamdb.info",
 	"homepage": "https://steamdb.info/",
 	"version": "1.5.1",
-	"icon": "icons/128.png",
+	"icon": "resource://firefox-extension-at-steamdb-dot-info/icons/128.png",
 	"main": "data/scripts/firefox.js",
 	"permissions":
 	{


### PR DESCRIPTION
According to [Mozilla's package.json docs](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json):

> When using jpm, relative path to the data directory (to make it re-usable for add-on HTML content) does not currently work. Instead you have to use following syntax:
>
> resource://ID/data/icon-name.png
>
> ID is the value from the id field. If it does not begin with the @-character, then @ has to be escaped as -at- and . as -dot-.
