### PR TITLE
Added option to partially hide market listings

### DIFF
--- a/BrowserExtension/manifest.json
+++ b/BrowserExtension/manifest.json
@@ -387,6 +387,21 @@
 				"scripts/common.js",
 				"scripts/community/market_ssa.js"
 			]
+		},
+		{
+			"matches":
+			[
+				"*://steamcommunity.com/market/*"
+			],
+			"js":
+			[
+				"scripts/common.js",
+				"scripts/community/market_sell_listings.js"
+			],
+			"css":
+			[
+				"styles/community.css"
+			]
 		}
 	]
 }

--- a/BrowserExtension/options/options.html
+++ b/BrowserExtension/options/options.html
@@ -145,6 +145,11 @@
 			Overwrite all http://steamcommunity.com links to be https
 			<div class="muted">(fixes workshop subscriptions, etc.)</div>
 		</label>
+		<label class="control checkbox">
+			<input type="checkbox" class="option-check" data-option="partially-show-market-sell-listings">
+			<span class="control-indicator"></span>
+			Partially hide all your market listing and buy order lists on market home page
+		</label>
 		
 		<h3>SteamDB Website</h3>
 		

--- a/BrowserExtension/package.json
+++ b/BrowserExtension/package.json
@@ -176,6 +176,12 @@
 			"title": "Overwrite all http://steamcommunity.com links to be https (fixes workshop subscriptions, etc.)",
 			"type": "bool",
 			"value": false
+		},
+		{
+			"name": "partially-show-market-sell-listings",
+			"title": "Partially hide all your market listing and buy order lists on market home page",
+			"type": "bool",
+			"value": false
 		}
 	]
 }

--- a/BrowserExtension/scripts/community/market_sell_listings.js
+++ b/BrowserExtension/scripts/community/market_sell_listings.js
@@ -1,0 +1,59 @@
+'use strict';
+
+GetOption( { 'partially-show-market-sell-listings': false }, function( items )
+{
+	if( items[ 'partially-show-market-sell-listings' ] )
+	{
+		var element = document.getElementById( 'tabContentsMyListings' );
+
+		if ( element )
+		{
+			var marketOrderTypes = element.querySelectorAll( '.my_listing_section.market_content_block.market_home_listing_table' );
+
+			for ( var i = 0; i < marketOrderTypes.length; i++ )
+			{
+				var listingCount = marketOrderTypes[i].querySelectorAll( '.market_listing_row.market_recent_listing_row' ).length;
+
+				if ( listingCount <= 5 )
+				{
+					continue;
+				}
+
+				marketOrderTypes[i].classList.add( 'steamdb_listing_partial' );
+
+				marketOrderTypes[i].classList.add( 'steamdb_list' + i );
+
+				var showMore = document.createElement( 'div' );
+				showMore.className = 'market_listing_table_showmore steamdb_listings_showmore';
+				showMore.dataset.referenceId = i;
+				marketOrderTypes[i].parentNode.insertBefore( showMore, marketOrderTypes[i].nextSibling );
+
+				var btn = document.createElement( 'span' );
+				btn.className = 'btnv6_blue_hoverfade btn_medium';
+				showMore.appendChild( btn );
+
+				var btnText = document.createElement( 'span' );
+				btnText.textContent = 'Show all';
+				btn.appendChild(btnText);
+
+				showMore.addEventListener( 'click', function(e) {
+					e.preventDefault();
+
+					var el = document.querySelector( '.steamdb_list' + this.dataset.referenceId );
+
+					if ( el ) {
+						if ( el.classList.contains( 'steamdb_listing_partial' ) )
+						{
+							el.classList.remove( 'steamdb_listing_partial' );
+							this.querySelector( 'span > span' ).textContent = 'Hide all';
+						}
+						else {
+							el.classList.add( 'steamdb_listing_partial' );
+							this.querySelector( 'span > span' ).textContent = 'Show all';
+						}
+					}
+				});
+			}
+		}
+	}
+} );

--- a/BrowserExtension/styles/community.css
+++ b/BrowserExtension/styles/community.css
@@ -50,3 +50,15 @@ a.apphub_NumInApp:hover {
 .profile_small_header_additional.steamdb {
 	margin-top: 40px;
 }
+
+.my_listing_section.market_content_block.market_home_listing_table.steamdb_listing_partial {
+	max-height: 340px;
+	overflow: hidden;
+	-webkit-mask-image: -webkit-gradient(linear, left 60%, left bottom, from(rgba(0,0,0,1)), to(rgba(0,0,0,0)));
+}
+
+@media screen and (max-width: 910px) {
+	.steamdb_listings_showmore {
+		margin-bottom: 10px;
+	}
+}


### PR DESCRIPTION
When you have many items listed on the market, and you visit the market home page, it is annoying to scroll down to other content of the page. Feature disabled by default.

![](http://i.imgur.com/vbpV9KE.png)